### PR TITLE
Fix assignment to entry in nil map

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "SchwarzIT/stackit"
-      version = "=0.1.2"
+      version = "=0.1.3"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "SchwarzIT/stackit"
-      version = "=0.1.2"
+      version = "=0.1.3"
     }
   }
 }

--- a/stackit/internal/resources/argus/job/helpers.go
+++ b/stackit/internal/resources/argus/job/helpers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/argus/jobs"
 	"github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -136,6 +137,9 @@ func (j *Job) handleTargets(cj jobs.Job) {
 			nt.Labels = j.Targets[i].Labels
 		} else {
 			nt.Labels = types.Map{ElemType: types.StringType}
+			if len(sc.Labels) > 0 {
+				nt.Labels.Elems = make(map[string]attr.Value, len(sc.Labels))
+			}
 			for k, v := range sc.Labels {
 				nt.Labels.Elems[k] = types.String{Value: v}
 			}


### PR DESCRIPTION
Bug found during E2E run:
```

panic: assignment to entry in nil map

goroutine 212 [running]:
github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job.(*Job).handleTargets(0xc000278870, {{0xc000582080, 0x1, 0x4}, {0xc0003fe634, 0x7}, {0xc0003fe630, 0x4}, {0xc0003fe63c, 0x2}, ...})
	github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job/helpers.go:140 +0x3d0
github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job.(*Job).FromClientJob(0xc000278870, {{0xc000582080, 0x1, 0x4}, {0xc0003fe634, 0x7}, {0xc0003fe630, 0x4}, {0xc0003fe63c, 0x2}, ...})
	github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job/helpers.go:88 +0x43d
github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job.Resource.Create.func1()
	github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/argus/job/actions.go:52 +0x265
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.RetryContext.func1()
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.21.0/helper/resource/wait.go:27 +0x56
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.(*StateChangeConf).WaitForStateContext.func1()
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.21.0/helper/resource/state.go:110 +0x1ff
created by github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.(*StateChangeConf).WaitForStateContext
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.21.0/helper/resource/state.go:83 +0x1d8

Error: The terraform-provider-stackit_v0.1.2 plugin crashed!

```