### PR TITLE
fix error with saml2 not passing correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Provider for STACKIT
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/SchwarzIT/terraform-provider-stackit)](https://goreportcard.com/report/github.com/SchwarzIT/terraform-provider-stackit) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/SchwarzIT/terraform-provider-stackit) [![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/gomods/athens.svg)](https://github.com/gomods/athens) [![License](https://img.shields.io/badge/License-Apache_2.0-lightgray.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/SchwarzIT/terraform-provider-stackit)](https://goreportcard.com/report/github.com/SchwarzIT/terraform-provider-stackit) [![Build Status](https://dev.azure.com/schwarzit/schwarzit.odj.core/_apis/build/status/Stackit/Stackit%20E2E%20Test?branchName=main&label=E2E%20Tests)](https://dev.azure.com/schwarzit/schwarzit.odj.core/_build/latest?definitionId=17957&branchName=main) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/SchwarzIT/terraform-provider-stackit) [![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/gomods/athens.svg)](https://github.com/gomods/athens) [![License](https://img.shields.io/badge/License-Apache_2.0-lightgray.svg)](https://opensource.org/licenses/Apache-2.0) 
 
 This provider is built and maintained by the STACKIT community in Schwarz IT and is not an official STACKIT provider
 
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "SchwarzIT/stackit"
-      version = "=0.1.3"
+      version = "=0.1.4"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     stackit = {
       source  = "SchwarzIT/stackit"
-      version = "=0.1.3"
+      version = "=0.1.4"
     }
   }
 }

--- a/stackit/internal/resources/argus/job/helpers.go
+++ b/stackit/internal/resources/argus/job/helpers.go
@@ -45,7 +45,7 @@ func (j *Job) ToClientJob() jobs.Job {
 
 	if j.SAML2 != nil && !j.SAML2.EnableURLParameters.Value {
 		if job.Params == nil {
-			job.Params = make(map[string]interface{}, 1)
+			job.Params = map[string]interface{}{}
 		}
 		job.Params["saml2"] = []string{"disabled"}
 	}
@@ -101,8 +101,7 @@ func (j *Job) handleBasicAuth(cj jobs.Job) {
 }
 
 func (j *Job) handleSAML2(cj jobs.Job) {
-	if cj.Params == nil {
-		j.SAML2 = nil
+	if cj.Params == nil && j.SAML2 == nil {
 		return
 	}
 
@@ -111,10 +110,11 @@ func (j *Job) handleSAML2(cj jobs.Job) {
 	}
 
 	flag := true
-	v, ok1 := cj.Params["saml2"]
-	if sl, ok2 := v.([]string); ok1 && ok2 {
-		if len(sl) == 1 && sl[0] == "disabled" {
-			flag = false
+	if v, ok := cj.Params["saml2"]; ok {
+		if sl, ok := v.([]string); ok {
+			if len(sl) == 1 && sl[0] == "disabled" {
+				flag = false
+			}
 		}
 	}
 

--- a/stackit/internal/resources/argus/job/resource_test.go
+++ b/stackit/internal/resources/argus/job/resource_test.go
@@ -84,6 +84,10 @@ resource "stackit_argus_job" "example" {
 		urls = ["url1", "url2"]
 	  }
 	]
+
+	saml2 = {
+	  enable_url_parameters = true
+	}
 }
   
 	  `,


### PR DESCRIPTION
Saml2 status wasn't created properly, which caused the provider to return the following error:

```
│ When applying changes to stackit_argus_job.argus_job, provider
│ "provider[\"registry.terraform.io/schwarzit/stackit\"]" produced an
│ unexpected new value: .saml2: was
│ cty.ObjectVal(map[string]cty.Value{"enable_url_parameters":cty.True}), but
│ now null.
```