### PR TITLE
Select highest patch version if only major and minor version given

### DIFF
--- a/examples/resources/stackit_kubernetes_cluster/resource.tf
+++ b/examples/resources/stackit_kubernetes_cluster/resource.tf
@@ -8,7 +8,7 @@ resource "stackit_project" "example" {
 resource "stackit_kubernetes_cluster" "example" {
   name               = "example"
   project_id         = stackit_project.example.id
-  kubernetes_version = "1.23.12"
+  kubernetes_version = "1.23"
 
   node_pool {
     name         = "example-np"

--- a/stackit/internal/data-sources/kubernetes/data_source_test.go
+++ b/stackit/internal/data-sources/kubernetes/data_source_test.go
@@ -68,7 +68,7 @@ func config(name, nodepoolName, machineType string) string {
 resource "stackit_kubernetes_cluster" "example" {
 	project_id         = "%s"
 	name               = "%s"
-	kubernetes_version = "1.23.12"
+	kubernetes_version = "1.23"
 	allow_privileged_containers = false
 	
 	node_pools = [{

--- a/stackit/internal/resources/kubernetes/resource_test.go
+++ b/stackit/internal/resources/kubernetes/resource_test.go
@@ -110,7 +110,7 @@ func configMinimal(name string) string {
 resource "stackit_kubernetes_cluster" "example" {
 	project_id         = "%s"
 	name               = "%s"
-	kubernetes_version = "1.23.12"
+	kubernetes_version = "1.23"
 	
 	node_pools = [{
 		name         = "example-np"
@@ -128,7 +128,7 @@ func configExtended(name, nodepoolName, machineType string) string {
 resource "stackit_kubernetes_cluster" "example" {
 	project_id         = "%s"
 	name               = "%s"
-	kubernetes_version = "1.23.12"
+	kubernetes_version = "1.23"
 	allow_privileged_containers = false
 	
 	node_pools = [{

--- a/stackit/internal/resources/kubernetes/schema.go
+++ b/stackit/internal/resources/kubernetes/schema.go
@@ -106,7 +106,7 @@ func (r Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) 
 				},
 			},
 			"kubernetes_version": {
-				Description: "Kubernetes version. Allowed Options are: `1.22.15`, `1.23.12`",
+				Description: "Kubernetes version. Allowed Options are: `1.22`, `1.22.15`, `1.23`, `1.23.12`",
 				Type:        types.StringType,
 				Optional:    true,
 				Validators: []tfsdk.AttributeValidator{

--- a/stackit/internal/resources/kubernetes/validations.go
+++ b/stackit/internal/resources/kubernetes/validations.go
@@ -42,6 +42,8 @@ func (r Resource) validate(
 		return err
 	}
 
+	clusterConfig.Version = maxVersionOption(clusterConfig.Version, opts.KubernetesVersions)
+
 	for _, np := range nodePools {
 		if err := validateMachineImage(np.Machine.Image.Name, np.Machine.Image.Version, opts.MachineImages); err != nil {
 			return err
@@ -58,6 +60,21 @@ func (r Resource) validate(
 	}
 
 	return nil
+}
+
+// maxVersionOption returns the maximal version that matches the given version.
+// If the given version only contains major and minor version, the latest patch version is returned.
+func maxVersionOption(version string, versionOptions []options.KubernetesVersion) string {
+	if strings.Count(version, ".") == 2 {
+		return version
+	}
+	ret := version
+	for _, v := range versionOptions {
+		if len(v.Version) > len(version) && strings.HasPrefix(v.Version, version+".") && v.Version > ret {
+			ret = v.Version
+		}
+	}
+	return ret
 }
 
 func validateKubernetesVersion(version string, versionOptions []options.KubernetesVersion) error {

--- a/stackit/internal/resources/kubernetes/validations_test.go
+++ b/stackit/internal/resources/kubernetes/validations_test.go
@@ -1,0 +1,34 @@
+package kubernetes
+
+import (
+	"github.com/SchwarzIT/community-stackit-go-client/pkg/api/v1/kubernetes/options"
+	"testing"
+)
+
+func Test_maxVersionOption(t *testing.T) {
+	type args struct {
+		version        string
+		versionOptions []options.KubernetesVersion
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{name: "patch version", args: args{version: "1.18.0", versionOptions: []options.KubernetesVersion{
+			{Version: "1.18.0"},
+			{Version: "1.18.1"},
+		}}, want: "1.18.0"},
+		{name: "minor version", args: args{version: "1.18", versionOptions: []options.KubernetesVersion{
+			{Version: "1.18.1"},
+			{Version: "1.18.0"},
+		}}, want: "1.18.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maxVersionOption(tt.args.version, tt.args.versionOptions); got != tt.want {
+				t.Errorf("maxVersionOption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will make acceptance tests less brittle, as no change will be necessary when only the patch version changes.