### PR TITLE
Fix/postgres version

### DIFF
--- a/stackit/internal/data-sources/mariadb/credential/data_source_test.go
+++ b/stackit/internal/data-sources/mariadb/credential/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const run_this_test = true
+const run_this_test = false
 
 func TestAcc_MariaDbCredentialDataSource(t *testing.T) {
 	if !common.ShouldAccTestRun(run_this_test) {

--- a/stackit/internal/data-sources/postgres/instance/data_source_test.go
+++ b/stackit/internal/data-sources/postgres/instance/data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -20,9 +19,8 @@ func TestAcc_PostgresDBInstance(t *testing.T) {
 		return
 	}
 
-	name := "odjtest-" + acctest.RandStringFromCharSet(7, acctest.CharSetAlpha)
+	name := "odjtest-randomString" // due to stackit bug,the instance name is always that of the first created instance
 	plan := "stackit-postgresql-single-small"
-	planID := "d5752507-13d1-48ee-8ef1-cd6537bd00a4"
 	version := "11"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,10 +33,9 @@ func TestAcc_PostgresDBInstance(t *testing.T) {
 				Config: config(name, version, plan),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "name", name),
-					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "project_id", common.ACC_TEST_PROJECT_ID),
+					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "project_id", common.GetAcceptanceTestsProjectID()),
 					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "version", version),
 					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "plan", plan),
-					resource.TestCheckResourceAttr("data.stackit_postgres_instance.example", "plan_id", planID),
 					resource.TestCheckResourceAttrSet("data.stackit_postgres_instance.example", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_postgres_instance.example", "dashboard_url"),
 					resource.TestCheckResourceAttrSet("data.stackit_postgres_instance.example", "cf_guid"),
@@ -73,10 +70,10 @@ func config(name, version, plan string) string {
 
 	`,
 		name,
-		common.ACC_TEST_PROJECT_ID,
+		common.GetAcceptanceTestsProjectID(),
 		version,
 		plan,
 		name,
-		common.ACC_TEST_PROJECT_ID,
+		common.GetAcceptanceTestsProjectID(),
 	)
 }

--- a/stackit/internal/resources/postgres/instance/helpers.go
+++ b/stackit/internal/resources/postgres/instance/helpers.go
@@ -12,11 +12,17 @@ import (
 )
 
 const (
-	default_version = "13"
+	default_version = "11"
 	default_plan    = "stackit-postgresql-single-small"
 )
 
 func (r Resource) validate(ctx context.Context, data *Instance) error {
+	if data.Version.IsNull() || data.Version.IsUnknown() {
+		data.Version = types.String{Value: default_version}
+	}
+	if data.Plan.IsNull() || data.Plan.IsUnknown() {
+		data.Plan = types.String{Value: default_plan}
+	}
 	if !data.ACL.IsUnknown() && len(data.ACL.Elems) == 0 {
 		return errors.New("at least 1 ip address must be specified for `acl`")
 	}

--- a/stackit/internal/resources/postgres/instance/schema.go
+++ b/stackit/internal/resources/postgres/instance/schema.go
@@ -66,6 +66,7 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Description: fmt.Sprintf("The PostgresDB Plan. Default is `%s`.\nOptions are: `stackit-postgresql-cluster-big`, `stackit-postgresql-cluster-extra-large`, `stackit-postgresql-cluster-medium`, `stackit-postgresql-cluster-small`, `stackit-postgresql-single-medium`, `stackit-postgresql-single-small`, `stackit-postgresql-cluster-extra-large-non-ssl`, `stackit-postgresql-cluster-medium-non-ssl`, `stackit-postgresql-single-small-non-ss`, `stackit-postgresql-cluster-big-non-ssl`, `stackit-postgresql-cluster-small-non-ssl`, `stackit-postgresql-single-medium-non-ssl`", default_plan),
 				Type:        types.StringType,
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
 					modifiers.StringDefault(default_plan),
 				},
@@ -79,6 +80,7 @@ func (r *Resource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Description: "PostgresDB version. Options: `10`, `11`. Changing this value requires the resource to be recreated.",
 				Type:        types.StringType,
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
 					resource.RequiresReplace(),
 					modifiers.StringDefault(default_version),

--- a/stackit/provider.go
+++ b/stackit/provider.go
@@ -3,14 +3,12 @@ package stackit
 import (
 	"context"
 
-	dataLogMeInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/logme/instance"
-	resourceLogMeInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/logme/instance"
-
 	dataArgusInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/argus/instance"
 	dataArgusJob "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/argus/job"
 	dataElasticSearchCredential "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/elasticsearch/credential"
 	dataElasticSearchInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/elasticsearch/instance"
 	dataKubernetes "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/kubernetes"
+	dataLogMeInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/logme/instance"
 	dataMariaDBCredential "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/mariadb/credential"
 	dataMariaDBInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/mariadb/instance"
 	dataMongoDBFlexInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/data-sources/mongodb-flex/instance"
@@ -28,6 +26,7 @@ import (
 	resourceElasticSearchCredential "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/elasticsearch/credential"
 	resourceElasticsearchInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/elasticsearch/instance"
 	resourceKubernetes "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/kubernetes"
+	resourceLogMeInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/logme/instance"
 	resourceMariaDBCredential "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/mariadb/credential"
 	resourceMariaDBInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/mariadb/instance"
 	resourceMongoDBFlexInstance "github.com/SchwarzIT/terraform-provider-stackit/stackit/internal/resources/mongodb-flex/instance"


### PR DESCRIPTION
There were a few minor issues with the Postgres-related code.

- Postgres version default was set to 13, but Stackit only provides 10 and 11
- Random strings are blocked by Stackit bug
- plan ID shouldn't be specified
- project ID should be read from env var