### PR TITLE
Updated Default Kubernetes Version

### DIFF
--- a/stackit/internal/resources/kubernetes/helpers.go
+++ b/stackit/internal/resources/kubernetes/helpers.go
@@ -26,7 +26,7 @@ const (
 	default_volume_size_gb           int64 = 20
 	default_cri                            = "containerd"
 	default_zone                           = "eu01-m"
-	default_version                        = "1.23"
+	default_version                        = "1.24.6"
 )
 
 func (r Resource) loadAvaiableVersions(ctx context.Context) ([]*semver.Version, error) {

--- a/stackit/internal/resources/kubernetes/helpers.go
+++ b/stackit/internal/resources/kubernetes/helpers.go
@@ -26,7 +26,7 @@ const (
 	default_volume_size_gb           int64 = 20
 	default_cri                            = "containerd"
 	default_zone                           = "eu01-m"
-	default_version                        = "1.24.6"
+	default_version                        = "1.24"
 )
 
 func (r Resource) loadAvaiableVersions(ctx context.Context) ([]*semver.Version, error) {


### PR DESCRIPTION
Updated the default Kubernetes version 1.23 to the STACKIT default version 1.24.6