### PR TITLE
improve acceptance tests to prevent dangling resources

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -21,7 +21,7 @@ jobs:
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
             --data-raw '{
               "name": "${{ github.event.repository.name }}.${{ github.ref_name }}.${{ github.run_id }}", \
-              "containerParentId": "${{ secrets.STACKIT_TEST_PROJECT_PARENT_ID }}", \
+              "containerParentId": "${{ secrets.STACKIT_ACC_TEST_PARENT_CONTAINER_ID }}", \
               "members": [ \
                 { \
                   "role": "project.owner", \

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -19,17 +19,7 @@ jobs:
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '{ \
-            "name": "${{ github.event.repository.name }}_${{ github.run_id }}", \
-            "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
-            "members": [{ \
-            "role": "project.owner", \
-            "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" \
-            }], \
-            "labels": { \
-            "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", \
-            "scope": "PUBLIC" \
-            }}' > $HOME/pr.json
+            --data-raw '{ "name": "${{ github.event.repository.name }}_${{ github.run_id }}", "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", "members": [{ "role": "project.owner", "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" }], "labels": { "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", "scope": "PUBLIC" }}' > $HOME/pr.json
           
           cat $HOME/pr.json
           

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -31,11 +31,13 @@ jobs:
           EOF
           )
           
+          echo "${JSON_DATA}"
+          
           curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '${JSON_DATA}' > $HOME/pr.json
+            --data-raw "${JSON_DATA}" > $HOME/pr.json
           
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=${ACC_TEST_PROJECT_ID}" >> $GITHUB_ENV

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Wait project created
         id: wait-project-active
-        needs: [ create-project ]
         uses: mydea/action-wait-for-api@v1
         with:
           url: 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -15,24 +15,7 @@ jobs:
         id: create-project
         shell: bash
         run: |
-          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
-            --header 'Content-Type: application/json' \
-            --header 'Accept: application/json' \
-            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '{ \
-              "name": "${{ github.event.repository.name }}_${{ github.run_id }}", \
-              "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
-              "members": [ \
-                { \
-                  "role": "project.owner", \
-                  "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" \
-                } \
-              ], \
-              "labels": { \
-                "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", \
-                "scope": "PUBLIC" \
-              } \
-            }' > $HOME/pr.json
+          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' --header 'Content-Type: application/json'--header 'Accept: application/json'--header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' --data-raw '{  "name": "${{ github.event.repository.name }}_${{ github.run_id }}",  "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",  "members": [    {      "role": "project.owner",      "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"    }  ],  "labels": {    "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",    "scope": "PUBLIC"  }}' > $HOME/pr.json
           cat $HOME/pr.json
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
@@ -68,6 +51,4 @@ jobs:
         shell: bash
         run:   |
           [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
-          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
-            --header 'Accept: application/json' \
-            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'
+          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'            --header 'Accept: application/json'--header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -15,11 +15,27 @@ jobs:
         id: create-project
         shell: bash
         run: |
+          JSON_DATA=$(cat << EOF
+          { 
+          "name": "${{ github.event.repository.name }}_${{ github.run_id }}", 
+          "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", 
+          "members": [{ 
+          "role": "project.owner", 
+          "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" 
+          }], 
+          "labels": { 
+          "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", 
+          "scope": "PUBLIC" 
+          }
+          }
+          EOF
+          )
+          
           curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '{ "name": "${{ github.event.repository.name }}_${{ github.run_id }}", "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", "members": [{ "role": "project.owner", "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" }], "labels": { "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", "scope": "PUBLIC" }}' > $HOME/pr.json
+            --data-raw '$JSON_DATA' > $HOME/pr.json
           
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=${ACC_TEST_PROJECT_ID}" >> $GITHUB_ENV

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -31,8 +31,6 @@ jobs:
           EOF
           )
           
-          echo "${JSON_DATA}"
-          
           curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -15,7 +15,7 @@ jobs:
         id: create-project
         shell: bash
         run: |
-          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' --header 'Content-Type: application/json'--header 'Accept: application/json'--header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' --data-raw '{  "name": "${{ github.event.repository.name }}_${{ github.run_id }}",  "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",  "members": [    {      "role": "project.owner",      "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"    }  ],  "labels": {    "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",    "scope": "PUBLIC"  }}' > $HOME/pr.json
+          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' --data-raw '{  "name": "${{ github.event.repository.name }}_${{ github.run_id }}",  "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",  "members": [    {      "role": "project.owner",      "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"    }  ],  "labels": {    "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",    "scope": "PUBLIC"  }}' > $HOME/pr.json
           cat $HOME/pr.json
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
@@ -51,4 +51,4 @@ jobs:
         shell: bash
         run:   |
           [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
-          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'            --header 'Accept: application/json'--header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'
+          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'            --header 'Accept: application/json' --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -35,7 +35,7 @@ jobs:
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '$JSON_DATA' > $HOME/pr.json
+            --data-raw '${JSON_DATA}' > $HOME/pr.json
           
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=${ACC_TEST_PROJECT_ID}" >> $GITHUB_ENV

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -34,9 +34,13 @@ jobs:
               } \
             }' > $HOME/pr.json
           cat $HOME/pr.json
+          ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
           echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
+          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
 
       - name: Wait project created
+        id: wait-project-active
+        needs: [ create-project ]
         uses: mydea/action-wait-for-api@v1
         with:
           url: 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'
@@ -56,9 +60,13 @@ jobs:
           go-version: 1.18
 
       - name: Test
+        id: acceptance-test
+        needs: [ create-project, wait-project-active ]
         run: make testacc ACC_TEST_BILLING_REF="${{ secrets.ACC_TEST_BILLING_REF }}" ACC_TEST_USER_EMAIL="${{ secrets.ACC_TEST_USER_EMAIL }}" STACKIT_SERVICE_ACCOUNT_TOKEN="${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}" STACKIT_SERVICE_ACCOUNT_EMAIL="${{ secrets.STACKIT_SERVICE_ACCOUNT_EMAIL }}"
 
       - name: Delete test project
+        id: delete-project
+        needs: [ create-project ]
         if: always()
         shell: bash
         run:   |

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -21,7 +21,7 @@ jobs:
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
             --data-raw '{
               "name": "${{ github.event.repository.name }}.${{ github.ref_name }}.${{ github.run_id }}", \
-              "containerParentId": "${{ secrets.STACKIT_ACC_TEST_PARENT_CONTAINER_ID }}", \
+              "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
               "members": [ \
                 { \
                   "role": "project.owner", \

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -55,4 +55,7 @@ jobs:
         shell: bash
         run:   |
           [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 0
-          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'            --header 'Accept: application/json' --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'
+          
+          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -56,6 +56,6 @@ jobs:
         run:   |
           [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 0
           
-          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
+          curl --location --request DELETE 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -21,11 +21,8 @@ jobs:
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
             --data-raw '{ "name": "${{ github.event.repository.name }}_${{ github.run_id }}", "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", "members": [{ "role": "project.owner", "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" }], "labels": { "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", "scope": "PUBLIC" }}' > $HOME/pr.json
           
-          cat $HOME/pr.json
-          
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
-          
-          echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
+          echo "ACC_TEST_PROJECT_ID=${ACC_TEST_PROJECT_ID}" >> $GITHUB_ENV
           [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1 || exit 0
 
       - name: Wait project created

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -19,7 +19,7 @@ jobs:
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
-            --data-raw '{
+            --data-raw '{ \
               "name": "${{ github.event.repository.name }}_${{ github.run_id }}", \
               "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
               "members": [ \

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -20,7 +20,7 @@ jobs:
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
             --data-raw '{
-              "name": "${{ github.event.repository.name }}.${{ github.ref_name }}.${{ github.run_id }}", \
+              "name": "${{ github.event.repository.name }}_${{ github.run_id }}", \
               "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
               "members": [ \
                 { \

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -33,6 +33,7 @@ jobs:
                 "scope": "PUBLIC" \
               } \
             }' > $HOME/pr.json
+          cat $HOME/pr.json
           echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
 
       - name: Wait project created

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -15,21 +15,21 @@ jobs:
         id: create-project
         shell: bash
         run: |
-          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects'
-          --header 'Content-Type: application/json'
-          --header 'Accept: application/json'
-          --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'
-          --data-raw '{
-          "name": "${{ github.event.repository.name }}_${{ github.run_id }}",
-          "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",
-          "members": [{
-          "role": "project.owner",
-          "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"
-          }],
-          "labels": {
-          "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",
-          "scope": "PUBLIC"
-          }}' > $HOME/pr.json
+          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
+            --data-raw '{ \
+            "name": "${{ github.event.repository.name }}_${{ github.run_id }}", \
+            "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}", \
+            "members": [{ \
+            "role": "project.owner", \
+            "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" \
+            }], \
+            "labels": { \
+            "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", \
+            "scope": "PUBLIC" \
+            }}' > $HOME/pr.json
           
           cat $HOME/pr.json
           

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -61,15 +61,14 @@ jobs:
 
       - name: Test
         id: acceptance-test
-        needs: [ create-project, wait-project-active ]
         run: make testacc ACC_TEST_BILLING_REF="${{ secrets.ACC_TEST_BILLING_REF }}" ACC_TEST_USER_EMAIL="${{ secrets.ACC_TEST_USER_EMAIL }}" STACKIT_SERVICE_ACCOUNT_TOKEN="${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}" STACKIT_SERVICE_ACCOUNT_EMAIL="${{ secrets.STACKIT_SERVICE_ACCOUNT_EMAIL }}"
 
       - name: Delete test project
         id: delete-project
-        needs: [ create-project ]
         if: always()
         shell: bash
         run:   |
+          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
           curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -11,6 +11,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Create test project
+        id: create-project
+        shell: bash
+        run: |
+          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' \
+            --data-raw '{
+              "name": "${{ github.event.repository.name }}.${{ github.ref_name }}.${{ github.run_id }}", \
+              "containerParentId": "${{ secrets.STACKIT_TEST_PROJECT_PARENT_ID }}", \
+              "members": [ \
+                { \
+                  "role": "project.owner", \
+                  "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}" \
+                } \
+              ], \
+              "labels": { \
+                "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}", \
+                "scope": "PUBLIC" \
+              } \
+            }' > $HOME/pr.json
+          echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
+
+      - name: Wait project created
+        uses: mydea/action-wait-for-api@v1
+        with:
+          url: 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'
+          headers: '{
+              "Accept": "application/json",
+              "Authorization": "Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}"
+            }'
+          expected-response-field: 'lifecycleState'
+          expected-response-field-value: 'ACTIVE'
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -21,3 +56,11 @@ jobs:
 
       - name: Test
         run: make testacc ACC_TEST_BILLING_REF="${{ secrets.ACC_TEST_BILLING_REF }}" ACC_TEST_USER_EMAIL="${{ secrets.ACC_TEST_USER_EMAIL }}" STACKIT_SERVICE_ACCOUNT_TOKEN="${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}" STACKIT_SERVICE_ACCOUNT_EMAIL="${{ secrets.STACKIT_SERVICE_ACCOUNT_EMAIL }}"
+
+      - name: Delete test project
+        if: always()
+        shell: bash
+        run:   |
+          curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -15,11 +15,28 @@ jobs:
         id: create-project
         shell: bash
         run: |
-          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects' --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}' --data-raw '{  "name": "${{ github.event.repository.name }}_${{ github.run_id }}",  "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",  "members": [    {      "role": "project.owner",      "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"    }  ],  "labels": {    "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",    "scope": "PUBLIC"  }}' > $HOME/pr.json
+          curl --location --request POST 'https://api.stackit.cloud/resource-management/v2/projects'
+          --header 'Content-Type: application/json'
+          --header 'Accept: application/json'
+          --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'
+          --data-raw '{
+          "name": "${{ github.event.repository.name }}_${{ github.run_id }}",
+          "containerParentId": "${{ secrets.ACC_TEST_PARENT_CONTAINER_ID }}",
+          "members": [{
+          "role": "project.owner",
+          "subject": "${{ secrets.ACC_TEST_USER_EMAIL }}"
+          }],
+          "labels": {
+          "billingReference": "${{ secrets.ACC_TEST_BILLING_REF }}",
+          "scope": "PUBLIC"
+          }}' > $HOME/pr.json
+          
           cat $HOME/pr.json
+          
           ACC_TEST_PROJECT_ID="$(jq -r '.projectId' $HOME/pr.json)"
+          
           echo "ACC_TEST_PROJECT_ID=$(jq -r '.projectId' $HOME/pr.json)" >> $GITHUB_ENV
-          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
+          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1 || exit 0
 
       - name: Wait project created
         id: wait-project-active
@@ -50,5 +67,5 @@ jobs:
         if: always()
         shell: bash
         run:   |
-          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 1
+          [[ -z "${ACC_TEST_PROJECT_ID}" || "${ACC_TEST_PROJECT_ID}" == "NULL" || "${ACC_TEST_PROJECT_ID}" == "null" ]] && exit 0
           curl --location --request GET 'https://api.stackit.cloud/resource-management/v2/projects/${{ env.ACC_TEST_PROJECT_ID }}'            --header 'Accept: application/json' --header 'Authorization: Bearer ${{ secrets.STACKIT_SERVICE_ACCOUNT_TOKEN }}'


### PR DESCRIPTION
added 3 stages to acceptance test action:
  1. create acceptance test project
  2. wait project is active
  - run acceptance tests in the created project -
  3. delete acceptance test project (should always run, even if test failed)