### PR TITLE
fix: Generate docs using the proper service name and Postgres supported version

### DIFF
--- a/docs/resources/elasticsearch_instance.md
+++ b/docs/resources/elasticsearch_instance.md
@@ -35,8 +35,8 @@ resource "stackit_elasticsearch_instance" "example" {
 ### Optional
 
 - `acl` (List of String) Access Control rules to whitelist IP addresses
-- `plan` (String) The RabbitMQ Plan. Default is `stackit-elasticsearch-single-small`
-- `version` (String) RabbitMQ version. Default is 7
+- `plan` (String) The ElasticSearch Plan. Default is `stackit-elasticsearch-single-small`
+- `version` (String) ElasticSearch version. Default is 7
 
 ### Read-Only
 

--- a/docs/resources/logme_instance.md
+++ b/docs/resources/logme_instance.md
@@ -35,8 +35,8 @@ resource "stackit_logme_instance" "example" {
 ### Optional
 
 - `acl` (List of String) Access Control rules to whitelist IP addresses
-- `plan` (String) The RabbitMQ Plan. Default is `stackit-logme-single-small-non-ssl`
-- `version` (String) RabbitMQ version. Default is LogMe
+- `plan` (String) The LogMe Plan. Default is `stackit-logme-single-small-non-ssl`
+- `version` (String) LogMe version. Default is LogMe
 
 ### Read-Only
 

--- a/docs/resources/mariadb_instance.md
+++ b/docs/resources/mariadb_instance.md
@@ -35,8 +35,8 @@ resource "stackit_mariadb_instance" "example" {
 ### Optional
 
 - `acl` (List of String) Access Control rules to whitelist IP addresses
-- `plan` (String) The RabbitMQ Plan. Default is `stackit-mariadb-single-small`
-- `version` (String) RabbitMQ version. Default is 10.4
+- `plan` (String) The MariaDB Plan. Default is `stackit-mariadb-single-small`
+- `version` (String) MariaDB version. Default is 10.4
 
 ### Read-Only
 

--- a/docs/resources/postgres_instance.md
+++ b/docs/resources/postgres_instance.md
@@ -19,7 +19,7 @@ Manages Postgres instances
 resource "stackit_postgres_instance" "example" {
   name       = "example"
   project_id = "example"
-  version    = "13"
+  version    = "11"
   plan       = "stackit-postgresql-single-small"
 }
 ```

--- a/docs/resources/postgres_instance.md
+++ b/docs/resources/postgres_instance.md
@@ -35,8 +35,8 @@ resource "stackit_postgres_instance" "example" {
 ### Optional
 
 - `acl` (List of String) Access Control rules to whitelist IP addresses
-- `plan` (String) The RabbitMQ Plan. Default is `stackit-postgresql-single-small`
-- `version` (String) RabbitMQ version. Default is 11
+- `plan` (String) The Postgres Plan. Default is `stackit-postgresql-single-small`
+- `version` (String) Postgres version. Default is 11
 
 ### Read-Only
 

--- a/docs/resources/redis_instance.md
+++ b/docs/resources/redis_instance.md
@@ -35,8 +35,8 @@ resource "stackit_redis_instance" "example" {
 ### Optional
 
 - `acl` (List of String) Access Control rules to whitelist IP addresses
-- `plan` (String) The RabbitMQ Plan. Default is `stackit-redis-single-small`
-- `version` (String) RabbitMQ version. Default is 6.0
+- `plan` (String) The Redis Plan. Default is `stackit-redis-single-small`
+- `version` (String) Redis version. Default is 6.0
 
 ### Read-Only
 

--- a/examples/resources/stackit_postgres_instance/resource.tf
+++ b/examples/resources/stackit_postgres_instance/resource.tf
@@ -1,6 +1,6 @@
 resource "stackit_postgres_instance" "example" {
   name       = "example"
   project_id = "example"
-  version    = "13"
+  version    = "11"
   plan       = "stackit-postgresql-single-small"
 }

--- a/stackit/internal/resources/data-services/instance/schema.go
+++ b/stackit/internal/resources/data-services/instance/schema.go
@@ -63,7 +63,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				},
 			},
 			"plan": schema.StringAttribute{
-				Description: fmt.Sprintf("The RabbitMQ Plan. Default is `%s`", r.getDefaultPlan()),
+				Description: fmt.Sprintf("The %s Plan. Default is `%s`", r.service.Display(), r.getDefaultPlan()),
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
@@ -75,7 +75,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				Computed:    true,
 			},
 			"version": schema.StringAttribute{
-				Description: fmt.Sprintf("RabbitMQ version. Default is %s", r.getDefaultVersion()),
+				Description: fmt.Sprintf("%s version. Default is %s", r.service.Display(), r.getDefaultVersion()),
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
All the service docs refer to RabbitMQ as the service, which is wrong. The example for postgres is also wrong as Postgres 13 isn't available
![image](https://user-images.githubusercontent.com/36899226/213453113-817ab34a-b32c-4e27-aff0-ca581ad626e3.png)

This PR solves the generation and updates the docs