### PR TITLE
Support all available k8s versions

### DIFF
--- a/stackit/internal/resources/kubernetes/cluster/helpers.go
+++ b/stackit/internal/resources/kubernetes/cluster/helpers.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/SchwarzIT/community-stackit-go-client/pkg/services/kubernetes/v1.0/cluster"
@@ -42,9 +41,6 @@ func (r Resource) loadAvaiableVersions(ctx context.Context, diags *diag.Diagnost
 	versionOptions = []*semver.Version{}
 	for _, v := range *opts.KubernetesVersions {
 		if v.State == nil || v.Version == nil {
-			continue
-		}
-		if !strings.EqualFold(*v.State, "supported") {
 			continue
 		}
 		versionOption, err := semver.NewVersion(*v.Version)


### PR DESCRIPTION
Currently terraform only allows updates to kubernetesVersions in state "supported" by explicitly only alow this versions from the /v1/provider-options response.  

In a regular update lifecycle a user also wants to be able to update to a version in state "preview", e.g. to test this new version in advance.  
Likewise, a user would also like to have the opportunity to install an old version which is in state "deprecated".  
After the ske api & portal supports the installation of this versions, this option should also exist within the tf provider.