### PR TITLE
update client to version 1.31

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/SchwarzIT/community-stackit-go-client v1.30.8
+	github.com/SchwarzIT/community-stackit-go-client v1.31.0
 	github.com/go-test/deep v1.0.3
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-framework v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/SchwarzIT/community-stackit-go-client v1.30.8 h1:O5R/i+ISeCr8GrW8LPeA+Gjzll5POgdZ3zgSb8RnfdA=
 github.com/SchwarzIT/community-stackit-go-client v1.30.8/go.mod h1:hlTfBNOKE1fokWE8g3KrI0AHo0SqzTKkS+LrIdhH8Qg=
+github.com/SchwarzIT/community-stackit-go-client v1.31.0 h1:kn5VS4Q4WZ6nekT5W9vmoFhAQdwNhdLRTei4f9XbWP4=
+github.com/SchwarzIT/community-stackit-go-client v1.31.0/go.mod h1:hlTfBNOKE1fokWE8g3KrI0AHo0SqzTKkS+LrIdhH8Qg=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=


### PR DESCRIPTION
might require testing to make sure nothing breaks

- dependency upgrade: stackit community go client -> new base URLs